### PR TITLE
Fix header check and translation SQL params

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,8 @@ from flask import Flask, send_from_directory, \
     g
 
 
-if str(locale.getpreferredencoding()).lower in ["utf-8", "utf8"]:
+# ensure the environment uses UTF-8 encoding
+if str(locale.getpreferredencoding()).lower() not in ["utf-8", "utf8"]:
     raise BaseException("Wrong encoding use utf8")
 
 if sys.version_info < (3,):
@@ -72,12 +73,15 @@ def format_datetime(value, format='%Y-%m-%d'):
 
 @app.after_request
 def add_header(response):
-    res = False
+    """Add caching headers for static assets when not in debug mode."""
     app.logger.debug(f"debugging ist {app.debug}")
-    if not app.debug and "text/css" in str(response.content_type) or "application/javascript" in str(response.content_type):
+    if not app.debug and (
+        "text/css" in str(response.content_type)
+        or "application/javascript" in str(response.content_type)
+    ):
         then = datetime.datetime.now() + datetime.timedelta(minutes=5)
-        response.headers['Cache-Control'] = 'public,max-age=1000'
-        response.headers['Expires'] = then.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        response.headers["Cache-Control"] = "public,max-age=1000"
+        response.headers["Expires"] = then.strftime("%a, %d %b %Y %H:%M:%S GMT")
     return response
 
 

--- a/app/translationdb.py
+++ b/app/translationdb.py
@@ -64,10 +64,10 @@ def getoraddtranslation(key,value):
 @with_appcontext
 def get_translation_command(key):
     db=get_db()
-    entry=db.execute(
-                'SELECT value FROM translation WHERE key=?',
-                (key)
-            ).fetchone()
+    entry = db.execute(
+        'SELECT value FROM translation WHERE key=?',
+        (key,)
+    ).fetchone()
     if entry is not None:
         click.echo(entry['value'])
         return entry['value']
@@ -81,9 +81,9 @@ def get_translation_command(key):
 def del_translation_command(key):
     db=get_db()
     db.execute(
-                'DELETE FROM translation WHERE key=?',
-                (key)
-            )
+        'DELETE FROM translation WHERE key=?',
+        (key,)
+    )
     db.commit()
 
 


### PR DESCRIPTION
## Summary
- enforce UTF-8 locale check correctly
- fix caching header condition in `add_header`
- use parameter tuples for translation database queries

## Testing
- `python3 -m py_compile app/*.py`
- `flake8 app/__init__.py app/translationdb.py`

------
https://chatgpt.com/codex/tasks/task_b_6883583416d88326936189dd9202eeac